### PR TITLE
Support for uwsgi

### DIFF
--- a/bima_back/tasks.py
+++ b/bima_back/tasks.py
@@ -71,6 +71,9 @@ def upload_photo(form_data, user_id, user_token, lang, create=True):
     data.update({'md5': _checksum_file(image_file, chunk_size)})
     client.action(schema, request_path, params=data)
 
+    # Request is not multipart, so we remove the header, otherwise uwsgi doesn't works
+    client.transports[0].headers._data.pop('content_type', None)
+
     # upload photo information
     form_data['image'] = img_id
     form_data['original_file_name'] = filename

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     'django-bootstrap-breadcrumbs>=0.8.1,<0.9',
     'django-bootstrap-pagination>=1.6.2,<1.7',
     'django-braces>=1.10,<1.12',
-    'django-chunked-upload>=1.1.1,<1.2',
+    'django-chunked-upload==1.1.1',
     'django-compressor>=2.1,<2.2',
     'django-constance[database]>=1.3.3,<2',
     'django-geoposition>=0.3,<0.4',


### PR DESCRIPTION
Changes to serve bima back in uwsgi.

* Fix version of django-chunked-upload to 1.1.1. Right now 1.1.2 doesn't works. It has been reported https://github.com/juliomalegria/django-chunked-upload/issues/33
* Fix the task that uploads and saves a file to the core